### PR TITLE
Update selected country when showDialCode is set

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -447,6 +447,7 @@ export default {
       if (this.inputOptions?.showDialCode && parsedCountry) {
         // Reset phone if the showDialCode is set
         this.phone = `+${parsedCountry.dialCode}`;
+        this.activeCountryCode = parsedCountry.iso2 || '';
         return;
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,6 +178,13 @@ export const allProps = [
     inDemo: false,
   },
   {
+    name: 'inputOptions.showDialCode',
+    default: false,
+    type: Boolean,
+    description: 'Show dial code in input',
+    inDemo: false,
+  },
+  {
     name: 'inputOptions.placeholder',
     default: 'Enter a phone number',
     type: String,


### PR DESCRIPTION
This fixes issue where, when `inputOptions.showDialCode` is set to true, flag isn't updated until full number is available. Fixes #283

Purposefully duplicated line to avoid refactoring `choose()` method, risking introducing regression issues

Also added missing documentation for inputOptions.showDialCode