### PR TITLE
Doc fix: move style tag *outside* of script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Or use the component directly:
       VueTelInput,
     },
   };
-
-  <style src="vue-tel-input/dist/vue-tel-input.css"></style>;
 </script>
+
+<style src="vue-tel-input/dist/vue-tel-input.css"></style>
 ```
 
 ### Browser


### PR DESCRIPTION
It's not valid syntax to have a `<style>` tag within the `<script>`
tag in a `.vue` file. Instead, move this example to its own top-level
attribute.

Notably, this matches the example in `docs/documentation/installation.md`