### PR TITLE
Add the ability to change dropdown width

### DIFF
--- a/src/assets/component.css
+++ b/src/assets/component.css
@@ -61,7 +61,6 @@
   left: -1px;
   background-color: #fff;
   border: 1px solid #ccc;
-  width: 390px;
 }
 .vti__dropdown-list.below {
   top: 33px;

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -30,6 +30,7 @@
         v-if="open"
         ref="list"
         class="vti__dropdown-list"
+        :style="{ width: dropdownOptions.width }"
         :class="dropdownOpenDirection"
         role="listbox"
       >

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,6 +123,12 @@ export const allProps = [
     inDemo: false,
   },
   {
+    name: 'dropdownOptions.width',
+    default: '390px',
+    type: String,
+    description: 'Specifiy dropdown width',
+  },
+  {
     name: 'ignoredCountries',
     default: [],
     type: Array,


### PR DESCRIPTION
Changing dropdown size only using css was not easily achievable since `vti__dropdown-list` was placed inside `vti__dropdown` making `width: 100%` not working properly.

I figured out adding a "dropdown width" option would be a much easier and cleaner solution.

Is that okay with you?