### PR TITLE
Added flag wrapper to fix width inconsistencies

### DIFF
--- a/src/assets/component.css
+++ b/src/assets/component.css
@@ -45,6 +45,11 @@
 .vti__selection .vti__country-code {
   color: #666;
 }
+.vti__flag-wrapper {
+  display: inline-block;
+  width: 30px;
+  text-align: center;
+}
 .vti__flag {
   margin-right: 5px;
   margin-left: 5px;

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -52,10 +52,12 @@
           @mousemove="selectedIndex = index"
           :aria-selected="activeCountryCode === pb.iso2 && !pb.preferred"
         >
-          <span
-            v-if="dropdownOptions.showFlags"
-            :class="['vti__flag', pb.iso2.toLowerCase()]"
-          ></span>
+          <div class="vti__flag-wrapper">
+            <span
+              v-if="dropdownOptions.showFlags"
+              :class="['vti__flag', pb.iso2.toLowerCase()]"
+            />
+          </div>
           <strong>{{ pb.name }}</strong>
           <span v-if="dropdownOptions.showDialCodeInList"> +{{ pb.dialCode }} </span>
         </li>


### PR DESCRIPTION
Switzerland flag width is 15px where every other flags are 20px this causes flags and texts misalignment.

This PR addresses the issue by adding a wrapper around the flag fixing the width to 30px (20px for the flag, 10px for both margins).