### PR TITLE
fix(build): use browserslist config on all chunks

### DIFF
--- a/.browserslistrc.legacy
+++ b/.browserslistrc.legacy
@@ -1,0 +1,1 @@
+> .5%, last 2 versions, not dead, ie >= 11

--- a/.browserslistrc.modern
+++ b/.browserslistrc.modern
@@ -1,0 +1,1 @@
+last 2 chrome version, last 2 firefox version, last 2 edge version, last 1 safari version

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/.vuepress/.temp/
 dist/
 dist-modern/
 Icon?
+.browserslistrc

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,16 +3,10 @@ module.exports = {
     [
       '@vue/cli-plugin-babel/preset',
       process.env.MODERN ? {
-        targets: {
-          browsers: "last 2 chrome version, last 2 firefox version, last 2 edge version, last 1 safari version",
-        },
         useBuiltIns: 'usage',
         corejs: { version: 3, proposals: true },
         exclude: ['transform-async-to-generator', 'transform-regenerator'],
       } : {
-        targets: {
-          browsers: "> .5%, last 2 versions, not dead",
-        },
         useBuiltIns: 'usage',
         corejs: { version: 3, proposals: true },
       },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "serve": "cd docs && npm run serve",
-    "build": "vue-cli-service build --target lib src/index.js --dest dist",
-    "build:modern": "MODERN=true vue-cli-service build --target lib src/index.js --dest dist-modern",
+    "build": "cp .browserslistrc.legacy .browserslistrc && vue-cli-service build --target lib src/index.js --dest dist",
+    "build:modern": "cp .browserslistrc.modern .browserslistrc && MODERN=true vue-cli-service build --target lib src/index.js --dest dist-modern",
     "docs:build": "cd docs && npm run build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",


### PR DESCRIPTION
The previous behavior that set browserslit config from babel.config.js
did not work on files not provided in repo (e.g. webpack bookstrap).

The new behavior copy the appropriate .browserslistrc file to the repo
before build.

Fixes IE 11 compatibility which was broken since https://github.com/iamstevendao/vue-tel-input/pull/264, release in `v5.4.0`.

see dist diff (`npm diff dist/vue-tel-input.umd.js`) :
```diff
diff --git a/dist/vue-tel-input.umd.js b/dist/vue-tel-input.umd.js
index v5.10.0..v5.10.0 100644
--- a/dist/vue-tel-input.umd.js
+++ b/dist/vue-tel-input.umd.js
@@ -8,7 +8,7 @@
        else
                root["vue-tel-input"] = factory();
 })((typeof self !== 'undefined' ? self : this), function() {
-return /******/ (() => { // webpackBootstrap
+return /******/ (function() { // webpackBootstrap
 /******/       var __webpack_modules__ = ({
 
 /***/ 7679:
@@ -97,7 +97,7 @@
 /***/ }),
 
 /***/ 3099:
-/***/ ((module) => {
+/***/ (function(module) {
```

IE does not supports arrow functions so they should not be in the dist file.

This fixes also removes unused polyfill from webpack internals inside the modern build (`npm diff dist-modern/vue-tel-input.umd.js`)