### PR TITLE
TypeError in dropdown search box

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -38,7 +38,7 @@
           v-if="dropdownOptions.showSearchBox"
           class="vti__input vti__search_box"
           aria-label="Search by country name or country code"
-          :placeholder="sortedCountries[0].name"
+          :placeholder="sortedCountries.length ? sortedCountries[0].name : ''"
           type="text"
           v-model="searchQuery"
         />


### PR DESCRIPTION
When search query do not match with the name or dial code of any countries, it throws an error-
 `TypeError: Cannot read properties of undefined (reading 'name’)` 
This error is coming from the placeholder of the search input which is binded with `sortedCountries[0].name`. 

Added a check on `sortedCountires.length` to catch this error.

<img width="1057" alt="Screenshot 2022-02-02 at 10 24 10 PM" src="https://user-images.githubusercontent.com/9108144/152205334-9125941b-8b72-4541-82e2-7809790915ab.png">

