### PR TITLE
event propagation in dropdown searchbox - Firefox & Safari

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -38,7 +38,7 @@
           v-if="dropdownOptions.showSearchBox"
           class="vti__input vti__search_box"
           aria-label="Search by country name or country code"
-          :placeholder="sortedCountries[0].name"
+          :placeholder="sortedCountries.length ? sortedCountries[0].name : ''"
           type="text"
           v-model="searchQuery"
         />

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -41,6 +41,7 @@
           :placeholder="sortedCountries.length ? sortedCountries[0].name : ''"
           type="text"
           v-model="searchQuery"
+          @click.stop
         />
         <li
           v-for="(pb, index) in sortedCountries"


### PR DESCRIPTION
Found this issue in both Safari and Firefox, When the cursor is focused on search input box, the dropdown gets closed. This is due to the event propagation happening from the input box, which ultimately calls the `clickedOutside` directive.

![ezgif-3-42c5f9a221](https://user-images.githubusercontent.com/9108144/152372473-72b8803b-824d-4205-8344-fd025ec883e8.gif)

