### PR TITLE
Addressing ref `undefined` issue #296

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -27,7 +27,7 @@
         </slot>
       </span>
       <ul
-        v-if="open"
+        v-show="open"
         ref="list"
         class="vti__dropdown-list"
         :style="{ width: dropdownOptions.width }"


### PR DESCRIPTION
As discussed in issue, change comes from ref being inaccessible right after `this.open` state has changed as change is yet to take affect in event loop