### PR TITLE
updating dependecy libphonenumber-js from ^1.9.6 to ^1.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "jsdelivr": "dist/vue-tel-input.umd.min.js",
   "dependencies": {
     "core-js": "^3.14.0",
-    "libphonenumber-js": "^1.9.6"
+    "libphonenumber-js": "^1.10.12"
   },
   "peerDependencies": {
     "vue": "^2.6.14"


### PR DESCRIPTION
reason:
doesn't get the right country.

the fix of this library was introduced on this commit: 
- https://gitlab.com/catamphetamine/libphonenumber-js/-/commit/6743a40c17a685698f656c634dfb9ab1124f47c9

Before:

https://user-images.githubusercontent.com/30967304/184786576-8ab32cb1-5e35-4685-a7c4-586b841f5eb7.mp4

After:

https://user-images.githubusercontent.com/30967304/184788070-4f1c80be-2eb4-447e-af14-bfa960e5567a.mov


