### PR TITLE
fix: special chars in showSearchBox

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -236,10 +236,13 @@ export default {
       if (!this.dropdownOptions.showSearchBox) {
         return countriesList;
       }
+      const userInput = this.searchQuery;
+      const cleanInput = userInput.replace(/[~`!@#$%^&*()+={}\[\];:\'\"<>.,\/\\\?-_]/g, '');
+
       return countriesList.filter(
-        (c) => (new RegExp(this.searchQuery, 'i')).test(c.name)
-          || (new RegExp(this.searchQuery, 'i')).test(c.iso2)
-          || (new RegExp(this.searchQuery, 'i')).test(c.dialCode),
+        (c) => (new RegExp(cleanInput, 'i')).test(c.name)
+          || (new RegExp(cleanInput, 'i')).test(c.iso2)
+          || (new RegExp(cleanInput, 'i')).test(c.dialCode),
       );
     },
     phoneObject() {


### PR DESCRIPTION
When you input special chars to showSearchBox, it throws an error as you can see in screenshot.
![Screenshot 2023-08-03 at 15 32 46](https://github.com/iamstevendao/vue-tel-input/assets/40266538/b58541d8-4c7a-4d4a-ae02-6c951e7e17db)

there is also an issue about this error: #402 

With this pr, special characters are ignored and countries are listed according to the entered letter or number. I didnt use `\W` or `[a-z0-9]` regex because it won't work for non english languages like chinese, arabic, turkish etc.