### PR TITLE
port character filter on `searchQuery` from vue3 version and increase by filtering leading `00`

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -245,10 +245,13 @@ export default {
       if (!this.dropdownOptions.showSearchBox) {
         return countriesList;
       }
+      const userInput = this.searchQuery;
+      const cleanInput = userInput.replace(/[~`!@#$%^&*()+={}\[\];:\'\"<>.,\/\\\?-_]/g, '');
+
       return countriesList.filter(
-        (c) => (new RegExp(this.searchQuery, 'i')).test(c.name)
-          || (new RegExp(this.searchQuery, 'i')).test(c.iso2)
-          || (new RegExp(this.searchQuery, 'i')).test(c.dialCode),
+        (c) => (new RegExp(cleanInput, 'i')).test(c.name)
+          || (new RegExp(cleanInput, 'i')).test(c.iso2)
+          || (new RegExp(cleanInput, 'i')).test(c.dialCode),
       );
     },
     phoneObject() {

--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -246,7 +246,7 @@ export default {
         return countriesList;
       }
       const userInput = this.searchQuery;
-      const cleanInput = userInput.replace(/[~`!@#$%^&*()+={}\[\];:\'\"<>.,\/\\\?-_]/g, '');
+      const cleanInput = userInput.replace(/[~`!@#$%^&*()+={}\[\];:\'\"<>.,\/\\\?-_]|^0{2,}/g, '');
 
       return countriesList.filter(
         (c) => (new RegExp(cleanInput, 'i')).test(c.name)


### PR DESCRIPTION
Hi @iamstevendao !
I ported character filtering from the current vue3 version to the legacy version because those characters might lead to an unhandled error. I also added a minor update on the filtering regex which will allow to search countries also by the old `00` notation like: `00351` for Portugal.

Can you please check this MR and include and create a release if it's ok for you? Let me know if you have any questions. :-)

Thanks in advance!