### PR TITLE
feat(vue-tel-input): emit event objects for standard events

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -530,18 +530,18 @@ export default {
       this.$emit('update:modelValue', value);
       this.$emit('on-input', value, this.phoneObject, this.$refs.input);
     },
-    onBlur() {
-      this.$emit('blur');
+    onBlur(e) {
+      this.$emit('blur', e);
     },
-    onFocus() {
+    onFocus(e) {
       setCaretPosition(this.$refs.input, this.phone.length);
-      this.$emit('focus');
+      this.$emit('focus', e);
     },
-    onEnter() {
-      this.$emit('enter');
+    onEnter(e) {
+      this.$emit('enter', e);
     },
-    onSpace() {
-      this.$emit('space');
+    onSpace(e) {
+      this.$emit('space', e);
     },
     focus() {
       this.$refs.input.focus();


### PR DESCRIPTION
This pull request proposes to include the actual event objects when emitting `blur`, `focus`, `enter` and `space`. This gives developers more control over side effects that may be triggered by those events.