### PR TITLE
countries: update DR Congo's extended name

### DIFF
--- a/src/assets/all-countries.js
+++ b/src/assets/all-countries.js
@@ -288,7 +288,7 @@ const allCountries = [
     '269',
   ],
   [
-    'Congo (DRC) (Jamhuri ya Kidemokrasia ya Kongo)',
+    'Congo (DRC) (République démocratique du Congo)',
     'cd',
     '243',
   ],


### PR DESCRIPTION
Change DR Congo's extended name to its French notation, which is the official language.