### PR TITLE
fix: exclude tests from TSConfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
     "src/index.js",
     "src/index.js"
   ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
Tests files should not be included into building types. 