### PR TITLE
fix: Error after tabbing to the dropdown field (#460)

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -26,7 +26,7 @@
         <span class="vti__dropdown-arrow">{{ data.open ? "▲" : "▼" }}</span>
       </slot>
       </span>
-      <ul v-if="data.open"
+      <ul v-show="data.open"
           ref="refList"
           :class="['vti__dropdown-list', data.dropdownOpenDirection]"
           role="listbox">


### PR DESCRIPTION
Fix foe issue #460 

In this fix, I have replaced the usage of v-if with v-show in instances where DOM elements are immediately targeted. Through this adjustment, we ensure smoother toggling of nodes while significantly improving performance, especially in scenarios where rapid toggling of elements occurs.