### PR TITLE
fix: prevent infinite loop in parsedMode calculation

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -257,7 +257,7 @@
   const parsedMode = computed<Lowercase<NumberFormat>>(() => {
     const mode = toLowerCase(props.mode)
     if (mode === 'auto') {
-      if (!data.phone || data.phone?.startsWith('+')) {
+      if (!data.phone?.startsWith('+')) {
         return 'national';
       }
       return 'international';


### PR DESCRIPTION
Fix for #462 (and potentially #452)

Issue in version >9 where if prop `mode` set to `auto` would be unable to change/edit the phone number input after the phone number has been formatted due to a bug in a compute value of `parsedMode` that leads to an endless changing of value of the `phoneObject` which would then change the `parsedMode` return value, which would then change the value of `phoneObject`, etc etc.

The main culprit of this seems to be of how an `if` condition is being handled making `parsedMode` return the inappropriate value when `result?.format(toUpperCase(parsedMode.value))` is being executed. 