### PR TITLE
Fix: Country search should not be case sensitive

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -278,7 +278,7 @@
     if (!props.dropdownOptions.showSearchBox) {
       return countriesList
     }
-    const userInput = data.searchQuery;
+    const userInput = data.searchQuery.toLowerCase();
     const cleanInput = userInput.replace(/[~`!@#$%^&*()+={}\[\];:\'\"<>.,\/\\\?-_]/g, '');
 
     return countriesList.filter(


### PR DESCRIPTION
**Issue**
Country search doesn't work for input containing capital letters (INDIA, inDIa).

**Steps to reproduce**

1. Enable dropdown options with `showSearchBox: true`
2. Type INDIA and check dropdown options
3. Type inDIa and check dropdown options
![image](https://github.com/iamstevendao/vue-tel-input/assets/8795134/dd24bd12-0930-40e8-8c02-0967ee98d5cb)

**Proposed solution**
Convert user input to lowercase before filtering the countries list

**After the fix**
![image](https://github.com/iamstevendao/vue-tel-input/assets/8795134/80241921-61b6-4b10-af85-f2e4d7478b0c)
