### PR TITLE
fix: Error after tabbing to the country field

### DIFF
--- a/src/components/vue-tel-input.vue
+++ b/src/components/vue-tel-input.vue
@@ -613,7 +613,7 @@
         choose(sortedCountries.value[data.selectedIndex]);
       }
       data.open = !data.open;
-    } else {
+    } else if (data.open) {
       // typing a country's name
       data.typeToFindInput += e.key;
       clearTimeout(data.typeToFindTimer);


### PR DESCRIPTION
Fix this error:

<img width="1675" alt="Capture d’écran 2024-06-06 à 13 40 59" src="https://github.com/iamstevendao/vue-tel-input/assets/7684148/00092f16-920f-45f9-81b3-1386cb46e723">

When we focus on the input flag, we press an alphanumeric character, the error appears.
