### PR TITLE
make libphonenumber-js external

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       polyfill: true,
     },
     rollupOptions: {
-      external: ['vue'],
+      external: ['vue', 'libphonenumber-js'],
       output: {
         globals: {
           vue: 'Vue',


### PR DESCRIPTION
libphonenumber-js was made a peer dependency but the build of this component ignores the user's installed version. This fix makes the package properly use the user's installed version of libphonenumber-js